### PR TITLE
Nix flake tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nix Flake
 - Docker image build using Nix `dockerTools`
 
+#### Changed
+
+- nixpkgs updated to latest `nixos-22.11` and hence NodeJS to `16.18.1`
+
 ## [1.4.0] - 2023-02-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Nix Flake
+- Docker image build using Nix `dockerTools`
+
 ## [1.4.0] - 2023-02-07
 
 ### Added

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675763311,
-        "narHash": "sha256-bz0Q2H3mxsF1CUfk26Sl9Uzi8/HFjGFD/moZHz1HebU=",
+        "lastModified": 1676253841,
+        "narHash": "sha256-jhuI8Mmky8VCD45OoJEuF6HdPLFBwNrHA0ljjZ/zkfw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fab09085df1b60d6a0870c8a89ce26d5a4a708c2",
+        "rev": "a45a8916243a7d27acc358f4fc18c4491f3eeca8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,10 @@
         inherit system;
         pkgs = legacyPkgs.${system};
       });
+      shell = lib.genAttrs supportedSystems (system: import ./shell.nix {
+        inherit system;
+        pkgs = legacyPkgs.${system};
+      });
     in
     {
       packages = forAllSystems (system: {
@@ -27,6 +31,9 @@
       });
       checks = forAllSystems (system: {
         inherit (self.packages.${system}) blockfrost-backend-ryo dockerImage;
+      });
+      devshells = forAllSystems (system: {
+        default = shell.${system};
       });
       apps = forAllSystems (system: {
         blockfrost-backend-ryo = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Blockfrost API backend";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
 
   outputs = { self, nixpkgs }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,14 @@
         inherit (default.${system}) blockfrost-backend-ryo;
         dockerImage = legacyPkgs.${system}.dockerTools.buildImage {
           name = "blockfrost";
+          runAsRoot = ''
+            #!${legacyPkgs.${system}.runtimeShell}
+            mkdir -p /app
+            cp -a ${self.packages.${system}.blockfrost-backend-ryo}/libexec/source/config /app/config
+          '';
           config = {
             Cmd = [ "${self.packages.${system}.blockfrost-backend-ryo}/bin/blockfrost-backend-ryo" ];
+            WorkingDir = "/app";
           };
         };
         default = self.packages.${system}.blockfrost-backend-ryo;

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,14 @@
-{}:
-let
-  # Pin the deployment package-set to a specific version of nixpkgs
-  pkgs = import
+{ pkgs ? let
+    lockfile = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nixpkgs = lockfile.nodes.nixpkgs.locked;
+  in
+  import
     (builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/00e376e3f3c22d991052dfeaf154c42b09deeb29.tar.gz";
-      sha256 = "0sj2lhx5yfphgamdpf0by237c44699yrqw3whs3frjydpvaiplnp";
+      url = "https://github.com/NixOS/nixpkgs/archive/${nixpkgs.rev}.tar.gz";
+      sha256 = nixpkgs.narHash;
     })
-    { };
-
-in
+    { }
+}:
 with pkgs;
 
 stdenv.mkDerivation {


### PR DESCRIPTION
Couple of adjustments to make `nix develop` and Docker image consistent with old ones.

Also made `shell.nix` use the same nixpkgs as `default.nix` from `flake.lock` and aligned with https://github.com/blockfrost/blockfrost-backend-ryo/pull/69